### PR TITLE
Enable circleci for mbed_lstools tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2.1
+commands:
+    setup_and_run_tests:
+        steps:
+            - checkout
+            - run:
+                name: Run mbed_lstools tests
+                working_directory: mbed_lstools
+                command: pip install --user -r test_requirements.txt
+            - run:
+                name: Run mbed_lstools tests
+                working_directory: mbed_lstools
+                command: python -m coverage run setup.py test
+jobs:
+    test_python27:
+        docker:
+            - image: circleci/python:2.7-stretch-node
+        steps:
+            - setup_and_run_tests
+    test_python35:
+        docker:
+            - image: circleci/python:3.5-stretch-node
+        steps:
+            - setup_and_run_tests
+    test_python36:
+        docker:
+            - image: circleci/python:3.6-stretch-node
+        steps:
+            - setup_and_run_tests
+    test_python37:
+        docker:
+            - image: circleci/python:3.7-stretch-node
+        steps:
+            - setup_and_run_tests
+workflows:
+    version: 2
+    test:
+        jobs:
+          - test_python27
+          - test_python35
+          - test_python36
+          - test_python37

--- a/mbed_lstools/test_requirements.txt
+++ b/mbed_lstools/test_requirements.txt
@@ -1,0 +1,2 @@
+coverage
+coveralls


### PR DESCRIPTION
CircleCI will now run the `mbed_lstools` tests for Python 2.7, 3.5, 3.6, and 3.7. I added 3.7 in this PR, turns out the tests all pass 😄 

Right now this effectively `cd`s into the `mbed_lstools` directory and just runs the tests, but the goal will be to move the tests back up to the root of the `mbed-tools` directory so there is only one suite of tests (for both `mbed_lstools` and `mbed_hosts_tests`). Baby steps though!