### PR TITLE
Redo test broken database

### DIFF
--- a/test/platform_database.py
+++ b/test/platform_database.py
@@ -70,7 +70,9 @@ class EmptyPlatformDatabaseTests(unittest.TestCase):
     def test_broken_database(self):
         """Verify that the platform database correctly reset's its database
         """
-        with patch("mbed_tools.detect.platform_database.open") as _open:
+        with patch("mbed_tools.detect.platform_database.open") as _open,\
+             patch("mbed_tools.detect.platform_database._older_than_me") as _older:
+            _older.return_value = False
             stringio = MagicMock()
             _open.side_effect = (IOError("Bogus"), stringio)
             self.pdb = PlatformDatabase([LOCAL_PLATFORM_DATABASE])


### PR DESCRIPTION
The way I fixed the `test_broken_database` test in #8 was incorrect and so I've reverted that commit.

This mocks the call to `_older_than_me` to always return `False`. This ensures that `open()` is always called twice, thus ensuring the control flow.