### PR TITLE
Count untested files towards coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
-include =
-    mbed_os_tools/*
+source =
+    mbed_os_tools


### PR DESCRIPTION
The purpose of this change is to further reduce our coverage score.

<br><br><br><br>

Ok not really. Previously, files that weren't being tested were not counting (negatively) towards our coverage score. This change includes these files in our coverage score, **so the coverage score will drop in this PR**.