### PR TITLE
Version into module

### DIFF
--- a/mbed_os_tools/__init__.py
+++ b/mbed_os_tools/__init__.py
@@ -12,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = "0.0.1"

--- a/mbed_os_tools/test/host_tests_plugins/module_reset_pyocd.py
+++ b/mbed_os_tools/test/host_tests_plugins/module_reset_pyocd.py
@@ -26,10 +26,6 @@ class HostTestPluginResetMethod_pyOCD(HostTestPluginBase):
 
     def __init__(self):
         """! ctor
-        @details We can check module version by referring to version attribute
-        import pkg_resources
-        print pkg_resources.require("mbed-host-tests")[0].version
-        '2.7'
         """
         HostTestPluginBase.__init__(self)
 

--- a/mbed_os_tools/test/host_tests_runner/host_test.py
+++ b/mbed_os_tools/test/host_tests_runner/host_test.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
 from sys import stdout
 from .mbed_base import Mbed
+from ... import __version__
 
 
 class HostTestResults(object):
@@ -123,9 +123,7 @@ class Test(HostTestResults):
     def get_hello_string(self):
         """ Hello string used as first print
         """
-        pkg = 'mbed-host-tests'
-        version = pkg_resources.require(pkg)[0].version
-        return "host test executor ver. " + version
+        return "host test executor ver. " + __version__
 
 
 class DefaultTestSelectorBase(Test):

--- a/mbed_os_tools/test/host_tests_runner/host_test_default.py
+++ b/mbed_os_tools/test/host_tests_runner/host_test_default.py
@@ -37,6 +37,7 @@ from .host_test import DefaultTestSelectorBase
 from ..host_tests_logger import HtrunLogger
 from ..host_tests_conn_proxy import conn_process
 from ..host_tests_toolbox.host_functional import handle_send_break_cmd
+from ... import __version__
 if (sys.version_info > (3, 0)):
     from queue import Empty as QueueEmpty
 else:
@@ -82,9 +83,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 sys.exit(0)
 
             if options.version:         # --version
-                import pkg_resources    # part of setuptools
-                version = pkg_resources.require("mbed-host-tests")[0].version
-                print(version)
+                print(__version__)
                 sys.exit(0)
 
             if options.send_break_cmd:  # -b with -p PORT (and optional -r RESET_TYPE)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ import os
 from distutils.core import setup
 from io import open
 from setuptools import find_packages
+import mbed_os_tools
 
 DESCRIPTION = "The tools to build, test, and work with Mbed OS"
 OWNER_NAMES = "Jimmy Brisson, Brian Daniels"
@@ -30,7 +31,7 @@ def read(fname):
 
 setup(
     name="mbed-os-tools",
-    version="0.0.1",
+    version=mbed_os_tools.__version__,
     description=DESCRIPTION,
     long_description=read("README.md"),
     author=OWNER_NAMES,


### PR DESCRIPTION
#41 seems to be failing since the code is checking the pip meta information to figure out what version it is, this seems a little backwards! Instead, I've moved the version into the `mbed_os_tools` module as a `__version__` attribute, which is suggested by [PEP8](https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names).