### PR TITLE
Remove import * from greentea legacy package

### DIFF
--- a/legacy/mbed-greentea/mbed_greentea/mbed_coverage_api.py
+++ b/legacy/mbed-greentea/mbed_greentea/mbed_coverage_api.py
@@ -17,4 +17,7 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 """
 
-from mbed_os_tools.test.mbed_coverage_api import *
+from mbed_os_tools.test.mbed_coverage_api import (
+    coverage_pack_hex_payload,
+    coverage_dump_file,
+)


### PR DESCRIPTION
I missed one `import *` call in the greentea legacy package. This PR replaces it with the relevant imports.