### PR TITLE
Optional pyocd dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     install_requires=[
         "PySerial>=3.0",
         "requests",
-        "pyocd==0.14.0",
         "intelhex",
         "future",
         "PrettyTable>=0.7.2",
@@ -58,5 +57,7 @@ setup(
         "colorama>=0.3,<0.5",
     ],
     tests_require=["mock>=2", "pytest>=3"],
-    extras_require={"colorized_logs": ["colorlog"]},
+    extras_require={
+        "pyocd": ["pyocd==0.14.0"]
+    },
 )

--- a/src/mbed_os_tools/test/host_tests_plugins/module_copy_pyocd.py
+++ b/src/mbed_os_tools/test/host_tests_plugins/module_copy_pyocd.py
@@ -15,9 +15,13 @@
 
 import os
 from .host_test_plugins import HostTestPluginBase
-from pyocd.core.helpers import ConnectHelper
-from pyocd.flash.loader import FileProgrammer
 
+try:
+    from pyocd.core.helpers import ConnectHelper
+    from pyocd.flash.loader import FileProgrammer
+    PYOCD_PRESENT = True
+except ImportError:
+    PYOCD_PRESENT = False
 
 class HostTestPluginCopyMethod_pyOCD(HostTestPluginBase):
     # Plugin interface
@@ -44,6 +48,13 @@ class HostTestPluginCopyMethod_pyOCD(HostTestPluginBase):
         @param kwargs Additional arguments
         @return Capability call return value
         """
+        if not PYOCD_PRESENT:
+            self.print_plugin_error(
+                'The "pyocd" feature is not installed. Please run '
+                '"pip install mbed-os-tools[pyocd]" to enable the "pyocd" copy plugin.'
+            )
+            return False
+
         if not self.check_parameters(capability, *args, **kwargs):
             return False
 

--- a/src/mbed_os_tools/test/host_tests_plugins/module_reset_pyocd.py
+++ b/src/mbed_os_tools/test/host_tests_plugins/module_reset_pyocd.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 
 from .host_test_plugins import HostTestPluginBase
-from pyocd.core.helpers import ConnectHelper
+
+try:
+    from pyocd.core.helpers import ConnectHelper
+    PYOCD_PRESENT = True
+except ImportError:
+    PYOCD_PRESENT = False
 
 
 class HostTestPluginResetMethod_pyOCD(HostTestPluginBase):
@@ -48,6 +53,13 @@ class HostTestPluginResetMethod_pyOCD(HostTestPluginBase):
         @details Each capability e.g. may directly just call some command line program or execute building pythonic function
         @return Capability call return value
         """
+        if not PYOCD_PRESENT:
+            self.print_plugin_error(
+                'The "pyocd" feature is not installed. Please run '
+                '"pip install mbed-os-tools[pyocd]" to enable the "pyocd" reset plugin.'
+            )
+            return False
+
         if not kwargs['target_id']:
             self.print_plugin_error("Error: target_id not set")
             return False


### PR DESCRIPTION
This change came out of a conversation with @RomanSaveljev. pyocd brings in quite a few different dependencies, including some native modules. This moves the pyocd dependency to a python "extra", so you don't get it by default but you can activate it with `pip install mbed-os-tools[pyocd]`.

If a user executes greentea with the `-c pyocd` or `-r pyocd` option, they will see and error message with instructions on how to install pyocd.

FYI @c1728p9 @flit