### PR TITLE
Ensure test filtering is case insensitive

### DIFF
--- a/src/mbed_os_tools/test/mbed_greentea_cli.py
+++ b/src/mbed_os_tools/test/mbed_greentea_cli.py
@@ -55,7 +55,7 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
 
     if test_by_names:
         filtered_ctest_test_list = {}   # Subset of 'ctest_test_list'
-        test_list = test_by_names.split(',')
+        test_list = test_by_names.lower().split(',')
         gt_logger.gt_log("test case filter (specified with -n option)")
 
         for test_name in set(test_list):

--- a/test/test/mbed_gt_cli.py
+++ b/test/test/mbed_gt_cli.py
@@ -115,5 +115,13 @@ class GreenteaCliFunctionality(unittest.TestCase):
         expected = set(['mbed-drivers-test-c_strings', 'mbed-drivers-test-generic_tests'])
         self.assertEqual(set(test_list.keys()), expected)
 
+        # Should be case insensitive
+        test_list = mbed_greentea_cli.create_filtered_test_list(test_build.get_tests(),
+                                                                '*-DRIVERS-*',
+                                                                None,
+                                                                test_spec=test_spec)
+        expected = set(['mbed-drivers-test-c_strings', 'mbed-drivers-test-generic_tests'])
+        self.assertEqual(set(test_list.keys()), expected)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a test to ~ensure #80 stays fixed~ fix #80 on Linux and Mac (was already working on Windows).