### PR TITLE
Update grm help text to say port is optional

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -176,7 +176,13 @@ def main():
 
     parser.add_option('-g', '--grm',
                     dest='global_resource_mgr',
-                    help='Global resource manager service query: platrform name, remote mgr module name, IP address and port, example K64F:module_name:10.2.123.43:3334')
+                    help=(
+                        'Global resource manager: "<platform name>:'
+                        '<remote mgr module>:<host url or IP address>[:<port>]", '
+                        'Ex. "K64F:module_name:10.2.123.43:3334", '
+                        '"K64F:module_name:https://example.com"'
+                    )
+    )
 
     # Show --fm option only if "fm_agent" module installed
     try:

--- a/src/mbed_os_tools/test/__init__.py
+++ b/src/mbed_os_tools/test/__init__.py
@@ -237,8 +237,9 @@ def init_host_test_cli_params():
         "--grm",
         dest="global_resource_mgr",
         help=(
-            "[Experimental] Global resource manager service module name, IP "
-            "and port, example remote_client:10.2.123.43:3334"
+            'Global resource manager: "<remote mgr module>:<host url or IP address>'
+            '[:<port>]", Ex. "module_name:10.2.123.43:3334", '
+            'module_name:https://example.com"'
         ),
     )
 


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->

PR #116 made providing a port to the `--grm` commands optional. It also allowed you to provide a protocol with the host. These fixes were made to the parsing of the command, but the help text was not updated. This should help clarify the updated parsing requirements.

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
