### PR TITLE
Fix flake8 errors

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
                 displayName: 'Install mbed-os test dependencies'
             -
                 script: |
-                    pip install --user flake8
+                    pip install --user flake8==3.7.3
                     python -m flake8
                 condition: eq(variables['extraActions'], 'true')
                 displayName: 'Enforce code style'

--- a/src/mbed_os_tools/detect/lstools_base.py
+++ b/src/mbed_os_tools/detect/lstools_base.py
@@ -398,9 +398,9 @@ class MbedLsToolsBase(object):
                     '-' remove mid from mocking entry
         @return Mocked structure (json format)
         """
-        if oper is "+":
+        if oper == "+":
             self.plat_db.add(mid, platform_name, permanent=True)
-        elif oper is "-":
+        elif oper == "-":
             self.plat_db.remove(mid, permanent=True)
         else:
             raise ValueError("oper can only be [+-]")

--- a/src/mbed_os_tools/detect/platform_database.py
+++ b/src/mbed_os_tools/detect/platform_database.py
@@ -514,7 +514,7 @@ class PlatformDatabase(object):
         as a dict.
         """
         logger.debug("Trying remove of %s", id)
-        if id is "*" and device_type in self._dbs[self._prim_db]:
+        if id == "*" and device_type in self._dbs[self._prim_db]:
             self._dbs[self._prim_db][device_type] = {}
             if permanent:
                 self._update_db()


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->

With version 3.7.3 of flake8, a few more errors were showing up in the
code that previously passed. This change pins the version of flake8 to
ensure the benchmark for "passing" isn't changing between each commit.
It also fixes the new errors that showed up.

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
