### PR TITLE
LPC55S69: Update the target name

### DIFF
--- a/src/mbed_os_tools/detect/platform_database.py
+++ b/src/mbed_os_tools/detect/platform_database.py
@@ -63,7 +63,7 @@ DEFAULT_PLATFORM_DB = {
         u"0230": u"K20D50M",
         u"0231": u"K22F",
         u"0234": u"RAPIDIOT_KW41Z",
-        u"0236": u"LPC55S69",
+        u"0236": u"LPC55S69_NS",
         u"0240": u"K64F",
         u"0245": u"K64F",
         u"0250": u"KW24D",


### PR DESCRIPTION
This is to handle both secure and non-secure targets inside mbed-os

### Description
Update the LPC55S69 target name. This is to handle both secure and non-secure targets inside mbed-os

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@maclobdell @bridadan 