### PR TITLE
Adding NUCLEO_L552ZE_Q and DISCO_L562QE

### DIFF
--- a/src/mbed_os_tools/detect/platform_database.py
+++ b/src/mbed_os_tools/detect/platform_database.py
@@ -171,6 +171,8 @@ DEFAULT_PLATFORM_DB = {
         u"0835": u"NUCLEO_F207ZG",
         u"0839": u"NUCLEO_WB55RG",
         u"0840": u"B96B_F446VE",
+        u"0854": u"NUCLEO_L552ZE_Q",
+        u"0855": u"DISCO_L562QE",
         u"0879": u"NUCLEO_F756ZG",
         u"0900": u"XPRO_SAMR21",
         u"0905": u"XPRO_SAMW25",


### PR DESCRIPTION
### Description

Hi

I would like to add 2 future ST boards based on STM32L5:
https://www.st.com/ko/microcontrollers/stm32l5x2.html?querycriteria=productId=LN2131

- NUCLEO_L552ZE_Q
- DISCO_L562QE

Thx

@lmestm @mikisch81 @orenc17 

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
