### PR TITLE
Revert "LPC55S69: Update the target name"

### DIFF
--- a/src/mbed_os_tools/detect/platform_database.py
+++ b/src/mbed_os_tools/detect/platform_database.py
@@ -63,7 +63,7 @@ DEFAULT_PLATFORM_DB = {
         u"0230": u"K20D50M",
         u"0231": u"K22F",
         u"0234": u"RAPIDIOT_KW41Z",
-        u"0236": u"LPC55S69_NS",
+        u"0236": u"LPC55S69",
         u"0240": u"K64F",
         u"0245": u"K64F",
         u"0250": u"KW24D",


### PR DESCRIPTION
This reverts commit b0eafe5edc323df400963ffdeeeaf2eac5e68655. (from #127). With https://github.com/ARMmbed/mbed-os/pull/9953 being merged, targets ending in `_NS` and `_PSA` are renamed back to the generic target name for test builds.

### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->

FYI @mmahadevan108 @orenc17 @juhhov @jussisip 

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
