### PR TITLE
Allow * as a device name in grm

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -686,7 +686,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
             gt_logger.gt_log_warn("entering global resource manager mbed-ls dummy mode!")
             grm_platform_name, grm_module_name, grm_ip_name, grm_port_name = grm_values
             mbeds_list = []
-            if grm_platform_name is '*':
+            if grm_platform_name == '*':
                 required_devices = [tb.get_platform() for tb in test_spec.get_test_builds()]
                 for _ in range(parallel_test_exec):
                     for device in required_devices:

--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -686,8 +686,14 @@ def main_cli(opts, args, gt_instance_uuid=None):
             gt_logger.gt_log_warn("entering global resource manager mbed-ls dummy mode!")
             grm_platform_name, grm_module_name, grm_ip_name, grm_port_name = grm_values
             mbeds_list = []
-            for _ in range(parallel_test_exec):
-                mbeds_list.append(mbeds.get_dummy_platform(grm_platform_name))
+            if grm_platform_name is '*':
+                required_devices = [tb.get_platform() for tb in test_spec.get_test_builds()]
+                for _ in range(parallel_test_exec):
+                    for device in required_devices:
+                        mbeds_list.append(mbeds.get_dummy_platform(device))
+            else:
+                for _ in range(parallel_test_exec):
+                    mbeds_list.append(mbeds.get_dummy_platform(grm_platform_name))
             opts.global_resource_mgr = ':'.join(grm_values[1:])
             gt_logger.gt_log_tab("adding dummy platform '%s'"% grm_platform_name)
         else:


### PR DESCRIPTION
### Description

Allowing * as device name in grm mode, this will scan the test_spec.json and add all the platform required as DUMMY platforms

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
