### PR TITLE
Fix greentea html generation in some cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 mbedls.json
 build/
 dist/
+.idea

--- a/src/mbed_os_tools/test/mbed_report_api.py
+++ b/src/mbed_os_tools/test/mbed_report_api.py
@@ -544,16 +544,23 @@ def get_result_overlay_testcase_dropdown(result_div_id, index, testcase_result_n
 
     testcase_utest_log_dropdown = get_dropdown_html(testcase_utest_div_id,
                                                     "uTest Log",
-                                                    "\n".join(testcase_result['utest_log']).rstrip("\n"),
+                                                    "\n".join(testcase_result.get('utest_log', 'n/a')).rstrip("\n"),
                                                     output_text=True,
                                                     sub_dropdown=True)
 
-    testcase_info = testcase_result_template % (testcase_result['result_text'],
-                                                testcase_result['duration'],
-                                                datetime.datetime.fromtimestamp(testcase_result['time_start']).strftime('%d-%m-%Y %H:%M:%S.%f'),
-                                                datetime.datetime.fromtimestamp(testcase_result['time_end']).strftime('%d-%m-%Y %H:%M:%S.%f'),
-                                                testcase_result['failed'],
-                                                testcase_result['passed'],
+    time_start = 'n/a'
+    time_end = 'n/a'
+    if 'time_start' in testcase_result.keys():
+        time_start = datetime.datetime.fromtimestamp(testcase_result['time_start']).strftime('%d-%m-%Y %H:%M:%S.%f')
+    if 'time_end' in testcase_result.keys():
+        time_end = datetime.datetime.fromtimestamp(testcase_result['time_end']).strftime('%d-%m-%Y %H:%M:%S.%f')
+
+    testcase_info = testcase_result_template % (testcase_result.get('result_text', 'n/a'),
+                                                testcase_result.get('duration', 'n/a'),
+                                                time_start,
+                                                time_end,
+                                                testcase_result.get('failed', 'n/a'),
+                                                testcase_result.get('passed', 'n/a'),
                                                 testcase_utest_log_dropdown)
 
     testcase_class = get_result_colour_class(testcase_result['result_text'])
@@ -563,6 +570,7 @@ def get_result_overlay_testcase_dropdown(result_div_id, index, testcase_result_n
                                           title_classes=testcase_class,
                                           sub_dropdown=True)
     return testcase_dropdown
+
 
 def get_result_overlay_testcases_dropdown_menu(result_div_id, test_results):
     """! Get the HTML for a test overlay's testcase dropdown menu


### PR DESCRIPTION
### Description

This is fix for very often seen problem in Mbed OS tests:

```
Traceback (most recent call last):
  File "/usr/local/bin/mbedgt", line 11, in <module>
    load_entry_point('mbed-greentea==1.6.3', 'console_scripts', 'mbedgt')()
  File "/usr/local/lib/python2.7/dist-packages/mbed_greentea-1.6.3-py2.7.egg/mbed_greentea/mbed_greentea_cli.py", line 357, in main
    cli_ret = main_cli(opts, args)
  File "/usr/local/lib/python2.7/dist-packages/mbed_greentea-1.6.3-py2.7.egg/mbed_greentea/mbed_greentea_cli.py", line 1023, in main_cli
    html_report = exporter_html(test_report)
  File "/usr/local/lib/python2.7/dist-packages/mbed_os_tools-0.0.4-py2.7.egg/mbed_os_tools/test/mbed_report_api.py", line 751, in exporter_html
    test_results)
  File "/usr/local/lib/python2.7/dist-packages/mbed_os_tools-0.0.4-py2.7.egg/mbed_os_tools/test/mbed_report_api.py", line 640, in get_result_overlay
    overlay_dropdowns = get_result_overlay_dropdowns(result_div_id, test_results)
  File "/usr/local/lib/python2.7/dist-packages/mbed_os_tools-0.0.4-py2.7.egg/mbed_os_tools/test/mbed_report_api.py", line 608, in get_result_overlay_dropdowns
    result_overlay_dropdowns = result_output_dropdown + get_result_overlay_testcases_dropdown_menu(result_div_id, test_results)
  File "/usr/local/lib/python2.7/dist-packages/mbed_os_tools-0.0.4-py2.7.egg/mbed_os_tools/test/mbed_report_api.py", line 580, in get_result_overlay_testcases_dropdown_menu
    testcase_results_info += get_result_overlay_testcase_dropdown(result_div_id, index, testcase_result_name, testcase_result)
  File "/usr/local/lib/python2.7/dist-packages/mbed_os_tools-0.0.4-py2.7.egg/mbed_os_tools/test/mbed_report_api.py", line 553, in get_result_overlay_testcase_dropdown
    datetime.datetime.fromtimestamp(testcase_result['time_start']).strftime('%d-%m-%Y %H:%M:%S.%f'),
KeyError: 'time_start'
```

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@alekla01 @bridadan @JuhPuur 
