### PR TITLE
Remove decode in mbed_report_api:get_result_overlay_dropdowns()

### DIFF
--- a/src/mbed_os_tools/test/mbed_report_api.py
+++ b/src/mbed_os_tools/test/mbed_report_api.py
@@ -603,11 +603,21 @@ def get_result_overlay_dropdowns(result_div_id, test_results):
     """
 
     # The HTML for the dropdown containing the ouput of the test
+    import sys
+
     result_output_div_id = "%s_output" % result_div_id
+
+    if sys.version_info >= (3, 0):
+        if type(test_results['single_test_output']) == bytes:
+            test_output = test_results['single_test_output'].decode('utf-8', 'backslashreplace')
+        else:
+            test_output = test_results['single_test_output']
+    else:
+        test_output = test_results['single_test_output'].decode('utf-8', 'replace')
+
     result_output_dropdown = get_dropdown_html(result_output_div_id,
                                                "Test Output",
-                                               test_results['single_test_output']
-                                               .decode("utf-8", "replace")
+                                               test_output
                                                .rstrip("\n"),
                                                output_text=True)
 

--- a/test/test/report_api.py
+++ b/test/test/report_api.py
@@ -15,6 +15,7 @@
 
 import unittest
 from mock import patch
+from copy import copy
 
 from mbed_os_tools.test.mbed_report_api import exporter_html, \
     exporter_memory_metrics_csv, exporter_testcase_junit, \
@@ -49,5 +50,8 @@ class ReportEmitting(unittest.TestCase):
                 }
             }
         }
+        # Pass a copy of the test data
+        # A function call may modify the test data, and the modified
+        # data will be passed on to the next tests.
         for report_fn in self.report_fns:
-            report_fn(test_data)
+            report_fn(copy(test_data))


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->
This decode call causes a failure when running greentea with python3 and removing it doesn't seem to affect anything in the html report.

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
 @OPpuolitaival 
