### PR TITLE
Fix string handling in different python versions

### DIFF
--- a/src/mbed_os_tools/test/mbed_report_api.py
+++ b/src/mbed_os_tools/test/mbed_report_api.py
@@ -604,11 +604,11 @@ def get_result_overlay_dropdowns(result_div_id, test_results):
 
     # The HTML for the dropdown containing the ouput of the test
     result_output_div_id = "%s_output" % result_div_id
-    result_output_dropdown = get_dropdown_html(result_output_div_id,
-                                               "Test Output",
-                                               test_results['single_test_output']
-                                               .decode("utf-8", "replace")
-                                               .rstrip("\n"),
+
+    test_output = test_results['single_test_output'] if type(test_results['single_test_output']) == str else \
+        test_results['single_test_output'].decode("utf-8", "replace")
+
+    result_output_dropdown = get_dropdown_html(result_output_div_id, "Test Output", test_output.rstrip("\n"),
                                                output_text=True)
 
     # Add a dropdown for the testcases if they are present


### PR DESCRIPTION
### Description

Fix for:
```
mbedgt: exporting to JUNIT file 'results/report_greentea_K66F_GCC_ARM.xml'...
mbedgt: exporting to HTML file 'results/report_greentea_K66F_GCC_ARM.html'...
mbedgt: unexpected error:
	'str' object has no attribute 'decode'
Traceback (most recent call last):
  File "C:\Python37\Lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Python37\Lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\jenkins\mbed-os-pyenv-python3.7-default\Scripts\mbedgt.exe\__main__.py", line 9, in <module>
  File "c:\jenkins\mbed-os-pyenv-python3.7-default\lib\site-packages\mbed_greentea\mbed_greentea_cli.py", line 357, in main
    cli_ret = main_cli(opts, args)
  File "c:\jenkins\mbed-os-pyenv-python3.7-default\lib\site-packages\mbed_greentea\mbed_greentea_cli.py", line 1017, in main_cli
    html_report = exporter_html(test_report)
  File "c:\jenkins\mbed-os-pyenv-python3.7-default\lib\site-packages\mbed_os_tools\test\mbed_report_api.py", line 751, in exporter_html
    test_results)
  File "c:\jenkins\mbed-os-pyenv-python3.7-default\lib\site-packages\mbed_os_tools\test\mbed_report_api.py", line 640, in get_result_overlay
    overlay_dropdowns = get_result_overlay_dropdowns(result_div_id, test_results)
  File "c:\jenkins\mbed-os-pyenv-python3.7-default\lib\site-packages\mbed_os_tools\test\mbed_report_api.py", line 601, in get_result_overlay_dropdowns
    test_results['single_test_output']
AttributeError: 'str' object has no attribute 'decode'
```


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
