### PR TITLE
Small bugfix: Error on bad disk name given in htrun

### DIFF
--- a/src/mbed_os_tools/test/host_tests_runner/mbed_base.py
+++ b/src/mbed_os_tools/test/host_tests_runner/mbed_base.py
@@ -88,6 +88,11 @@ class Mbed:
             """! Get the remount count from 'DETAILS.TXT' file
             @return Returns count, None if not-available
             """
+
+            #In case of no disk path, nothing to do
+            if disk_path is None:
+                return None
+                
             for cur_try in range(1, tries + 1):
                 try:
                     files_on_disk = [x.upper() for x in os.listdir(disk_path)]


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->
When remounting the user provides the name of the disk, given in `disk_path` variable. If the uset did not give a disk path (like when using stlink / jtag), then the program crashes without any meaningful error message (due to the fact that the call to the `get_mount_count` function is not protected by a `try/except` block).
After this change, the function reports an error (by returning `None` which is already checked for in the calling function).

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
