### PR TITLE
ST-LINK Plugin bugfix: Create temp file containing an Enter tab and pass it to ST-LINK CLI

### DIFF
--- a/src/mbed_os_tools/test/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/src/mbed_os_tools/test/host_tests_conn_proxy/conn_primitive_serial.py
@@ -31,6 +31,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         self.write_timeout = 5
         self.config = config
         self.target_id = self.config.get('target_id', None)
+        self.mcu = self.config.get('mcu', None)
         self.polling_timeout = config.get('polling_timeout', 60)
         self.forced_reset_timeout = config.get('forced_reset_timeout', 1)
         self.skip_reset = config.get('skip_reset', False)
@@ -86,6 +87,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
             reset_type,
             serial=self.serial,
             disk=disk,
+            mcu=self.mcu,
             target_id=self.target_id,
             polling_timeout=self.config.get('polling_timeout'))
         # Post-reset sleep

--- a/src/mbed_os_tools/test/host_tests_plugins/host_test_plugins.py
+++ b/src/mbed_os_tools/test/host_tests_plugins/host_test_plugins.py
@@ -221,18 +221,17 @@ class HostTestPluginBase:
             return False
         return True
 
-    def run_command(self, cmd, shell=True, stdin = None, stdout = None):
+    def run_command(self, cmd, shell=True, stdin = None):
         """! Runs command from command line.
         @param cmd Command to execute
         @param shell True if shell command should be executed (eg. ls, ps)
         @param stdin A custom stdin for the process running the command (defaults to None)
-        @param stdout A custom stdout for the process running the command (defaults to None)
         @details Function prints 'cmd' return code if execution failed
         @return True if command successfully executed
         """
         result = True
         try:
-            ret = call(cmd, shell=shell, stdin=stdin, stdout=stdout)
+            ret = call(cmd, shell=shell, stdin=stdin)
             if ret:
                 self.print_plugin_error("[ret=%d] Command: %s"% (int(ret), cmd))
                 return False

--- a/src/mbed_os_tools/test/host_tests_plugins/host_test_plugins.py
+++ b/src/mbed_os_tools/test/host_tests_plugins/host_test_plugins.py
@@ -221,16 +221,18 @@ class HostTestPluginBase:
             return False
         return True
 
-    def run_command(self, cmd, shell=True):
+    def run_command(self, cmd, shell=True, stdin = None, stdout = None):
         """! Runs command from command line.
         @param cmd Command to execute
         @param shell True if shell command should be executed (eg. ls, ps)
+        @param stdin A custom stdin for the process running the command (defaults to None)
+        @param stdout A custom stdout for the process running the command (defaults to None)
         @details Function prints 'cmd' return code if execution failed
         @return True if command successfully executed
         """
         result = True
         try:
-            ret = call(cmd, shell=shell)
+            ret = call(cmd, shell=shell, stdin=stdin, stdout=stdout)
             if ret:
                 self.print_plugin_error("[ret=%d] Command: %s"% (int(ret), cmd))
                 return False

--- a/src/mbed_os_tools/test/host_tests_plugins/module_reset_stlink.py
+++ b/src/mbed_os_tools/test/host_tests_plugins/module_reset_stlink.py
@@ -17,7 +17,6 @@ import os
 import sys
 import tempfile
 from .host_test_plugins import HostTestPluginBase
-from .host_tests_logger import HtrunLogger
 
 FIX_FILE_NAME = "enter_file.txt"
 
@@ -51,7 +50,6 @@ class HostTestPluginResetMethod_Stlink(HostTestPluginBase):
     def setup(self, *args, **kwargs):
         """! Configure plugin, this function should be called before plugin execute() method is used.
         """
-        self.logger = HtrunLogger('STLINK_RESET_PLUGIN')
         # Note you need to have eACommander.exe on your system path!
         self.ST_LINK_CLI = 'ST-LINK_CLI.exe'
         return True
@@ -66,7 +64,7 @@ class HostTestPluginResetMethod_Stlink(HostTestPluginBase):
             with open(file_path, "w") as fix_file:
                 fix_file.write(os.linesep)
         except (OSError, IOError):
-            self.logger.prn_err("Error opening STLINK-PRESS-ENTER-BUG file")
+            self.print_plugin_error("Error opening STLINK-PRESS-ENTER-BUG file")
             sys.exit(1)
 
 
@@ -95,16 +93,11 @@ class HostTestPluginResetMethod_Stlink(HostTestPluginBase):
                 enter_file_path = os.path.join(tempfile.gettempdir(), FIX_FILE_NAME)
                 self.create_stlink_fix_file(enter_file_path)
                 try:
-                    with open(enter_fix_file, 'r') as fix_file:
-                        std_args = {'stdin' : fix_file}
-                        if 'stdin' in kwargs:
-                            std_args['stdin'] = kwargs['stdin']
-                        if 'stdout' in kwargs:
-                            std_args['stdout'] = kwargs['stdout']
-
-                        result = self.run_command(cmd, **std_args)
+                    with open(enter_file_path, 'r') as fix_file:
+                        stdin_arg = kwargs.get('stdin', fix_file)
+                        result = self.run_command(cmd, stdin = stdin_arg)
                 except (OSError, IOError):
-                    self.logger.prn_err("Error opening STLINK-PRESS-ENTER-BUG file")
+                    self.print_plugin_error("Error opening STLINK-PRESS-ENTER-BUG file")
                     sys.exit(1)
 
         return result

--- a/src/mbed_os_tools/test/host_tests_runner/host_test_default.py
+++ b/src/mbed_os_tools/test/host_tests_runner/host_test_default.py
@@ -164,6 +164,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
             "digest" : "serial",
             "port" : self.mbed.port,
             "baudrate" : self.mbed.serial_baud,
+            "mcu" : self.mbed.mcu,
             "program_cycle_s" : self.options.program_cycle_s,
             "reset_type" : self.options.forced_reset_type,
             "target_id" : self.options.target_id,

--- a/src/mbed_os_tools/test/host_tests_runner/mbed_base.py
+++ b/src/mbed_os_tools/test/host_tests_runner/mbed_base.py
@@ -36,6 +36,7 @@ class Mbed:
         self.logger = HtrunLogger('MBED')
         # Options related to copy / reset mbed device
         self.port = self.options.port
+        self.mcu = self.options.micro
         self.disk = self.options.disk
         self.target_id = self.options.target_id
         self.image_path = self.options.image_path.strip('"') if self.options.image_path is not None else ''
@@ -80,7 +81,7 @@ class Mbed:
                 self.logger.prn_err("Test configuration JSON Unexpected error:", str(e))
                 raise
 
-    def copy_image(self, image_path=None, disk=None, copy_method=None, port=None, retry_copy=5):
+    def copy_image(self, image_path=None, disk=None, copy_method=None, port=None, mcu=None, retry_copy=5):
         """! Closure for copy_image_raw() method.
         @return Returns result from copy plugin
         """
@@ -167,6 +168,8 @@ class Mbed:
             copy_method = self.copy_method
         if not port:
             port = self.port
+        if not mcu:
+            mcu = self.mcu
         if not retry_copy:
             retry_copy = self.retry_copy
         target_id = self.target_id
@@ -182,7 +185,7 @@ class Mbed:
         for count in range(0, retry_copy):
             initial_remount_count = get_remount_count(disk)
             # Call proper copy method
-            result = self.copy_image_raw(image_path, disk, copy_method, port)
+            result = self.copy_image_raw(image_path, disk, copy_method, port, mcu)
             sleep(self.program_cycle_s)
             if not result:
                 continue
@@ -191,7 +194,7 @@ class Mbed:
                 break
         return result
 
-    def copy_image_raw(self, image_path=None, disk=None, copy_method=None, port=None):
+    def copy_image_raw(self, image_path=None, disk=None, copy_method=None, port=None, mcu=None):
         """! Copy file depending on method you want to use. Handles exception
              and return code from shell copy commands.
         @return Returns result from copy plugin
@@ -209,6 +212,7 @@ class Mbed:
         result = ht_plugins.call_plugin('CopyMethod',
                                         copy_method,
                                         image_path=image_path,
+                                        mcu=mcu,
                                         serial=port,
                                         destination_disk=disk,
                                         target_id=self.target_id,


### PR DESCRIPTION
### Description
Fixes #147. 
Implement the resolution suggested there.
Not sure if this counts as breaking change as it breaks the API of the `src` directory (and not the `packages`) and the documentation states this API is not stable.
<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
