### PR TITLE
Fix string decoding reports

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -23,6 +23,7 @@ import sys
 import random
 import optparse
 import imp
+import io
 from time import time
 try:
     from Queue import Queue
@@ -980,7 +981,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
             @return True if write was successful, else return False
             """
             try:
-                with open(filename, 'w') as f:
+                with io.open(filename, encoding="utf-8", errors="backslashreplace", mode="w") as f:
                     f.write(content)
             except IOError as e:
                 gt_logger.gt_log_err("can't export to '%s', reason:"% filename)

--- a/packages/mbed-greentea/test/report_api.py
+++ b/packages/mbed-greentea/test/report_api.py
@@ -44,7 +44,7 @@ class ReportEmitting(unittest.TestCase):
                     u'build_path_abs': u'N/A',
                     u'copy_method': u'N/A',
                     u'image_path': u'N/A',
-                    u'single_test_output': b'\x80abc\uXXXX' ,
+                    u'single_test_output': u'\x80abc' ,
                     u'platform_name': u'k64f',
                     u'test_bin_name': u'N/A',
                     u'testcase_result': {},

--- a/src/mbed_os_tools/test/mbed_report_api.py
+++ b/src/mbed_os_tools/test/mbed_report_api.py
@@ -37,8 +37,7 @@ def exporter_json(test_result_ext, test_suite_properties=None):
     for target in test_result_ext.values():
         for suite in target.values():
             try:
-                suite["single_test_output"] = suite["single_test_output"]\
-                                              .decode("utf-8", "replace")
+                suite["single_test_output"] = suite["single_test_output"]
             except KeyError:
                 pass
     return json.dumps(test_result_ext, indent=4)
@@ -161,16 +160,7 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
         test_results = test_result_ext[target_name]
         for test_suite_name in test_results:
             test = test_results[test_suite_name]
-
-            try:
-                if sys.version_info >= (3, 0):
-                    tc_stdout = str(test['single_test_output']).encode('ascii', 'ignore')
-                else:
-                    tc_stdout = test['single_test_output'].decode('unicode_escape').encode('ascii', 'ignore')
-            except UnicodeDecodeError as e:
-                err_mgs = "(UnicodeDecodeError) exporter_testcase_junit:", str(e)
-                tc_stdout = err_mgs
-                print(err_mgs)
+            tc_stdout = test['single_test_output']
 
             # testcase_result stores info about test case results
             testcase_result = test['testcase_result']
@@ -189,18 +179,7 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
                 utest_log = testcase_result[tc_name].get('utest_log', '')
                 result_text = testcase_result[tc_name].get('result_text', "UNDEF")
 
-                try:
-                    lines = '\n'.join(utest_log)
-
-                    if sys.version_info >= (3, 0):
-                        tc_stderr = str(lines).encode('ascii', 'ignore')
-                    else:
-                        tc_stderr = lines.decode('unicode_escape').encode('ascii', 'ignore')
-                except UnicodeDecodeError as e:
-                    err_mgs = "(UnicodeDecodeError) exporter_testcase_junit:" + str(e)
-                    tc_stderr = err_mgs
-                    print(err_mgs)
-
+                tc_stderr = '\n'.join(utest_log)
                 tc_class = target_name + '.' + test_suite_name
 
                 if result_text == 'SKIPPED':
@@ -604,12 +583,11 @@ def get_result_overlay_dropdowns(result_div_id, test_results):
 
     # The HTML for the dropdown containing the ouput of the test
     result_output_div_id = "%s_output" % result_div_id
-    result_output_dropdown = get_dropdown_html(result_output_div_id,
-                                               "Test Output",
-                                               test_results['single_test_output']
-                                               .decode("utf-8", "replace")
-                                               .rstrip("\n"),
-                                               output_text=True)
+    result_output_dropdown = get_dropdown_html(
+        result_output_div_id, "Test Output",
+        test_results['single_test_output'].rstrip("\n"),
+        output_text=True
+    )
 
     # Add a dropdown for the testcases if they are present
     if len(test_results) > 0:

--- a/test/test/report_api.py
+++ b/test/test/report_api.py
@@ -42,7 +42,7 @@ class ReportEmitting(unittest.TestCase):
                     u'build_path_abs': u'N/A',
                     u'copy_method': u'N/A',
                     u'image_path': u'N/A',
-                    u'single_test_output': b'\x80abc\uXXXX' ,
+                    u'single_test_output': u'\x80abc',
                     u'platform_name': u'k64f',
                     u'test_bin_name': u'N/A',
                     u'testcase_result': {},


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->

This is a follow up to #144. Htrun output should be a decoded string, however the reports were attempting decode this string again, which caused tracebacks in Python 3. This PR updates some tests to match the output of htrun, as well updates the report APIs.

This was tested locally with Python 3.6 and 2.7.


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@theotherjimmy @JuhPuur 
