### PR TITLE
Add STM_S2LP (WiSUN) MTB

### DIFF
--- a/src/mbed_os_tools/detect/platform_database.py
+++ b/src/mbed_os_tools/detect/platform_database.py
@@ -104,6 +104,7 @@ DEFAULT_PLATFORM_DB = {
         u"0462": u"MTB_USI_WM_BN_BM_22",
         u"0465": u"MTB_LAIRD_BL654",
         u"0466": u"MTB_MURATA_WSM_BL241",
+        u"0467": u"MTB_STM_S2LP",
         u"0468": u"MTB_STM_L475",
         u"0469": u"MTB_STM32_F439",
         u"0472": u"MTB_ACONNO_ACN52832",


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->
0467 = board ID assigned to MTB_STM_S2LP. This PR adds support for WiSUN HW (S2_LP) on an MCB using the STM32F429 MCU.
PE Platform database also updated. Target doesn't have a platform page, so slug field not updated.

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy @bridadan 