### PR TITLE
Remove links to old repos

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -2,9 +2,9 @@
 
 `mbed-os-tools` is the name of the unified tools pip package. From this codebase, we release the other pip packages:
 
-- `mbed-ls` (Mbed LS): https://github.com/ARMmbed/mbed-ls
-- `mbed-host-tests` (htrun): https://github.com/ARMmbed/htrun
-- `mbed-greentea` (greentea): https://github.com/ARMmbed/greentea
+- `mbed-ls` (Mbed LS): https://pypi.org/project/mbed-ls
+- `mbed-host-tests` (htrun): https://pypi.org/project/mbed-host-tests
+- `mbed-greentea` (greentea): https://pypi.org/project/mbed-greentea
 
 ## Package and API structure
 

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -14,9 +14,9 @@ The goal of delivering the unified Mbed OS tools is to improve testing and quali
 
 The tools are currently in separate packages:
 
-- `mbed-ls` (Mbed LS): https://github.com/ARMmbed/mbed-ls
-- `mbed-host-tests` (htrun): https://github.com/ARMmbed/htrun
-- `mbed-greentea` (greentea): https://github.com/ARMmbed/greentea
+- `mbed-ls` (Mbed LS): https://pypi.org/project/mbed-ls
+- `mbed-host-tests` (htrun): https://pypi.org/project/mbed-host-tests
+- `mbed-greentea` (greentea): https://pypi.org/project/mbed-greentea
 
 They all have their own test suites of varying completeness. Part of the effort of bringing these projects into the unified tools packages was to get these test suites passing consistently under all operating systems.
 

--- a/packages/mbed-greentea/README.md
+++ b/packages/mbed-greentea/README.md
@@ -158,7 +158,7 @@ $ mbedgt --use-tids 02400203C3423E603EBEC3D8,024002031E031E6AE3FFE3D2
 
 Where ```02400203C3423E603EBEC3D8``` and ```024002031E031E6AE3FFE3D2``` are the target IDs of platforms attached to your system.
 
-You can view target IDs using the [mbed-ls](https://github.com/ARMmbed/mbed-ls) tool (installed with Greentea).
+You can view target IDs using the [mbed-ls](https://pypi.org/project/mbed-ls) tool (installed with Greentea).
 
 ```
 $ mbedls

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     version=read("src/mbed_os_tools/VERSION.txt").strip(),
     description=DESCRIPTION,
     long_description=read("README.md"),
+    long_description_content_type='text/markdown',
     author=OWNER_NAMES,
     author_email=OWNER_EMAILS,
     maintainer=OWNER_NAMES,


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->

This takes some links that were pointing to the old GitHub repositories and points them to PyPI instead.

It should also fix the rendering of the README in PyPI for the mbed-os-tools package.


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
