### PR TITLE
Add support for "compare_log" in GreenTea test_spec.json

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -424,6 +424,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          enum_host_tests_path=enum_host_tests_path,
                                          global_resource_mgr=opts.global_resource_mgr,
                                          fast_model_connection=opts.fast_model_connection,
+                                         compare_log=test['compare_log'],
                                          num_sync_packtes=opts.num_sync_packtes,
                                          tags=opts.tags,
                                          retry_count=opts.retry_count,
@@ -872,10 +873,11 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
             for test_name in filtered_ctest_test_list_keys:
                 image_path = filtered_ctest_test_list[test_name].get_binary(binary_type=TestBinary.BIN_TYPE_BOOTABLE).get_path()
+                compare_log = filtered_ctest_test_list[test_name].get_binary(binary_type=TestBinary.BIN_TYPE_BOOTABLE).get_comp_log()
                 if image_path is None:
                     gt_logger.gt_log_err("Failed to find test binary for test %s flash method %s" % (test_name, 'usb'))
                 else:
-                    test = {"test_bin": test_name, "image_path": image_path}
+                    test = {"test_bin": test_name, "image_path": image_path, "compare_log": compare_log}
                     test_queue.put(test)
 
             number_of_threads = 0

--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -873,7 +873,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
             for test_name in filtered_ctest_test_list_keys:
                 image_path = filtered_ctest_test_list[test_name].get_binary(binary_type=TestBinary.BIN_TYPE_BOOTABLE).get_path()
-                compare_log = filtered_ctest_test_list[test_name].get_binary(binary_type=TestBinary.BIN_TYPE_BOOTABLE).get_comp_log()
+                compare_log = filtered_ctest_test_list[test_name].get_binary(binary_type=TestBinary.BIN_TYPE_BOOTABLE).get_compare_log()
                 if image_path is None:
                     gt_logger.gt_log_err("Failed to find test binary for test %s flash method %s" % (test_name, 'usb'))
                 else:

--- a/packages/mbed-greentea/mbed_greentea/mbed_test_api.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_test_api.py
@@ -74,6 +74,7 @@ def run_host_test(image_path,
                   enum_host_tests_path=None,
                   global_resource_mgr=None,
                   fast_model_connection=None,
+                  compare_log=None,
                   num_sync_packtes=None,
                   polling_timeout=None,
                   retry_count=1,
@@ -212,7 +213,8 @@ def run_host_test(image_path,
         # Example:
         # $ mbedhtrun -f "tests-mbed_drivers-generic_tests.elf" -m FVP_MPS2_M3 --fm DEFAULT
         cmd += ['--fm', fast_model_connection]
-
+    if compare_log:
+        cmd += ['--compare-log', compare_log]
     if program_cycle_s:
         cmd += ["-C", str(program_cycle_s)]
     if forced_reset_timeout:

--- a/src/mbed_os_tools/test/tests_spec.py
+++ b/src/mbed_os_tools/test/tests_spec.py
@@ -57,7 +57,8 @@ class TestBinary:
         :return:
         """
         return self.__path
-    def get_comp_log(self):
+
+    def get_compare_log(self):
         """
         Gives compare log file.
         :return:
@@ -117,7 +118,9 @@ class Test:
             ), "Binary spec should contain key [%s]" % ",".join(mandatory_keys)
             fm = binary.get(TestBinary.KW_BIN_TYPE, self.__default_flash_method)
             assert fm is not None, "Binary type not specified in build and binary spec."
-            tb = TestBinary(binary[TestBinary.KW_BIN_PATH], fm, binary.get(TestBinary.KW_COMP_LOG))
+            tb = TestBinary(binary[TestBinary.KW_BIN_PATH],
+                            fm,
+                            binary.get(TestBinary.KW_COMP_LOG))
             self.__binaries_by_flash_method[fm] = tb
 
     def add_binary(self, path, binary_type, compare_log=None):
@@ -128,7 +131,9 @@ class Test:
         :param binary_type:
         :return:
         """
-        self.__binaries_by_flash_method[binary_type] = TestBinary(path, binary_type, compare_log)
+        self.__binaries_by_flash_method[binary_type] = TestBinary(path,
+                                                                  binary_type,
+                                                                  compare_log)
 
 
 class TestBuild:

--- a/src/mbed_os_tools/test/tests_spec.py
+++ b/src/mbed_os_tools/test/tests_spec.py
@@ -29,12 +29,13 @@ class TestBinary:
 
     KW_BIN_TYPE = "binary_type"
     KW_BIN_PATH = "path"
+    KW_COMP_LOG = "compare_log"
 
     BIN_TYPE_BOOTABLE = "bootable"
     BIN_TYPE_DEFAULT = BIN_TYPE_BOOTABLE
     SUPPORTED_BIN_TYPES = [BIN_TYPE_BOOTABLE]
 
-    def __init__(self, path, binary_type):
+    def __init__(self, path, binary_type, compare_log):
         """
         ctor.
 
@@ -48,6 +49,7 @@ class TestBinary:
         )
         self.__path = path
         self.__flash_method = binary_type
+        self.__comp_log = compare_log
 
     def get_path(self):
         """
@@ -55,6 +57,12 @@ class TestBinary:
         :return:
         """
         return self.__path
+    def get_comp_log(self):
+        """
+        Gives compare log file.
+        :return:
+        """
+        return self.__comp_log
 
 
 class Test:
@@ -109,10 +117,10 @@ class Test:
             ), "Binary spec should contain key [%s]" % ",".join(mandatory_keys)
             fm = binary.get(TestBinary.KW_BIN_TYPE, self.__default_flash_method)
             assert fm is not None, "Binary type not specified in build and binary spec."
-            tb = TestBinary(binary[TestBinary.KW_BIN_PATH], fm)
+            tb = TestBinary(binary[TestBinary.KW_BIN_PATH], fm, binary.get(TestBinary.KW_COMP_LOG))
             self.__binaries_by_flash_method[fm] = tb
 
-    def add_binary(self, path, binary_type):
+    def add_binary(self, path, binary_type, compare_log=None):
         """
         Add binary to the test.
 
@@ -120,7 +128,7 @@ class Test:
         :param binary_type:
         :return:
         """
-        self.__binaries_by_flash_method[binary_type] = TestBinary(path, binary_type)
+        self.__binaries_by_flash_method[binary_type] = TestBinary(path, binary_type, compare_log)
 
 
 class TestBuild:


### PR DESCRIPTION
### Description

This change add the support for "compare_log" key in the test_spec.json file
This change would allow mbed-os examples be tested by passing a customized test_spec.json file.
And utilized HTrun [log compare](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples) function.

The normal Green Tea test functions will not be impacted.

Detailed changes:
 * in TestBinary class add compare_log member to the constructor
 * in Greentea passing the compare_log to HTrun command line

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

