### PR TITLE
Revise M263 board name

### DIFF
--- a/src/mbed_os_tools/detect/platform_database.py
+++ b/src/mbed_os_tools/detect/platform_database.py
@@ -228,7 +228,7 @@ DEFAULT_PLATFORM_DB = {
         u"1307": u"NUMAKER_PFM_NUC240",
         u"1308": u"NUMAKER_IOT_M487",
         u"1309": u"NUMAKER_M252KG",
-        u"1310": u"NUMAKER_M263KI",
+        u"1310": u"NUMAKER_IOT_M263A",
         u"1500": u"RHOMBIO_L476DMW1K",
         u"1549": u"LPC1549",
         u"1600": u"LPC4330_M4",


### PR DESCRIPTION
### Description
Revise Nuvoton M263 board name as NUMAKER_IOT_M263A to match real board's label name.

### Pull request type

    [v] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
