### PR TITLE
Rename M2351 platform name to 'NU_PFM_M2351' from 'NUMAKER_PFM_M2351'

### DIFF
--- a/src/mbed_os_tools/detect/platform_database.py
+++ b/src/mbed_os_tools/detect/platform_database.py
@@ -225,7 +225,7 @@ DEFAULT_PLATFORM_DB = {
         u"1302": u"NUMAKER_PFM_NUC472",
         u"1303": u"NUMAKER_PFM_M453",
         u"1304": u"NUMAKER_PFM_M487",
-        u"1305": u"NUMAKER_PFM_M2351",
+        u"1305": u"NU_PFM_M2351",
         u"1306": u"NUMAKER_PFM_NANO130",
         u"1307": u"NUMAKER_PFM_NUC240",
         u"1308": u"NUMAKER_IOT_M487",


### PR DESCRIPTION
### Description

Originally its name is **NUMAKER_PFM_M2351**. After adding suffix to distinguish PSA/non-PSA targets, it will have pattern below which exceeds max 20 chars limited by online database:
```
'NUMAKER_PFM_M2351'+'_'+['PSA', 'NOPSA']+'_'+['S', 'NS']
```

To fix the issue, the M2351 platform name is changed to **NU_PFM_M2351**. Then it will have pattern below for PSA/non-PSA targets, which fit in max 20 chars limit:
```
'NU_PFM_M2351'+'_'+['P', 'NP']+'_'+['S', 'NS']
```

#### Related PR

https://github.com/ARMmbed/mbed-os/pull/11288

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [x] Breaking change

### Reviewers

@MarceloSalazar @mark-edgeworth 