### PR TITLE
Use return code 0 when all tests are skipped

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -1049,10 +1049,8 @@ def main_cli(opts, args, gt_instance_uuid=None):
         if test_platforms_match == 0:
             # No tests were executed
             gt_logger.gt_log_warn("no platform/target matching tests were found!")
-            test_exec_retcode += -10
         if target_platforms_match == 0:
             # No platforms were tested
             gt_logger.gt_log_warn("no matching platforms were found!")
-            test_exec_retcode += -100
 
     return (test_exec_retcode)


### PR DESCRIPTION
### Description

In Mbed OS pull request checks we use `--skip-test` to skip tests which did pass already. In case of all tests are skipped greentea returns 1. This PR change to return zero when all tests are skipped. This makes Greentea to behave more similar way that another test frameworks.


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
