### PR TITLE
Remove decode call from report content write

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -983,7 +983,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
             """
             try:
                 with io.open(filename, encoding="utf-8", errors="backslashreplace", mode="w") as f:
-                    f.write(content.decode('utf-8'))
+                    f.write(content)
             except IOError as e:
                 gt_logger.gt_log_err("can't export to '%s', reason:"% filename)
                 gt_logger.gt_log_err(str(e))


### PR DESCRIPTION
### Description

This one decode call breaks reporting for python3.
<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
