### PR TITLE
Try quick way first and fall back to robust way if it fails.

### DIFF
--- a/src/mbed_os_tools/detect/darwin.py
+++ b/src/mbed_os_tools/detect/darwin.py
@@ -48,7 +48,7 @@ def _plist_from_popen(popen):
         except ExpatError:
             # Beautiful soup ensures the XML is properly formed after it is parsed
             # so that it can be used by other less lenient commands without problems
-            xml_representation = BeautifulSoup(out.decode('utf8'), 'xml', parse_only=soup_strainer)
+            xml_representation = BeautifulSoup(out.decode('utf8'), 'xml')
 
             if not xml_representation.get_text():
                 # The output is not in the XML format

--- a/src/mbed_os_tools/detect/darwin.py
+++ b/src/mbed_os_tools/detect/darwin.py
@@ -42,13 +42,18 @@ def _plist_from_popen(popen):
     if not out:
         return []
     try:
-        # Beautiful soup ensures the XML is properly formed after it is parsed
-        # so that it can be used by other less lenient commands without problems
-        xml_representation = BeautifulSoup(out.decode('utf8'), 'xml')
-        if not xml_representation.get_text():
-            # The output is not in the XML format
+        try:
+            # Try simple and fast first if this fails fall back to the slower but better process
             return loads(out)
-        return loads(xml_representation.decode().encode('utf8'))
+        except ExpatError:
+            # Beautiful soup ensures the XML is properly formed after it is parsed
+            # so that it can be used by other less lenient commands without problems
+            xml_representation = BeautifulSoup(out.decode('utf8'), 'xml', parse_only=soup_strainer)
+
+            if not xml_representation.get_text():
+                # The output is not in the XML format
+                return loads(out)
+            return loads(xml_representation.decode().encode('utf8'))
     except ExpatError:
         return []
 


### PR DESCRIPTION
### Description

A fix was added in the last release to handle board detection when the a debug probe was added. This however meant that the detection was an order of magnitude slower.

This change tries the original quick way first and then fall back to the more robust way. This means for the majority of use cases it will be quicker but still work (albeit slower when the debug probe is connected).


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Testing

Before change:
```
▶ time mbedls   
| platform_name | platform_name_unique | mount_point   | serial_port            | target_id                | daplink_version |
|---------------|----------------------|---------------|------------------------|--------------------------|-----------------|
| K64F          | K64F[0]              | /Volumes/MBED | /dev/tty.usbmodem14202 | 02400201CCF63E703108C3C8 | 0201            |
mbedls  1.30s user 0.17s system 85% cpu 1.717 total
```

After change:
```                                                                                                                                                                                                                                   
▶ time mbedls
| platform_name | platform_name_unique | mount_point   | serial_port            | target_id                | daplink_version |
|---------------|----------------------|---------------|------------------------|--------------------------|-----------------|
| K64F          | K64F[0]              | /Volumes/MBED | /dev/tty.usbmodem14202 | 02400201CCF63E703108C3C8 | 0201            |
mbedls  0.38s user 0.12s system 90% cpu 0.552 total
(ls_test) 
```
