### PR TITLE
FIx CI failures before release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,19 +37,19 @@ jobs:
                     sendCoverage: "true"
                 mac_python_2_7:
                     python.version: "2.7"
-                    imageName: macos-10.13
+                    imageName: macOS-10.15
                     sendCoverage: "false"
                 mac_python_3_5:
                     python.version: "3.5"
-                    imageName: macos-10.13
+                    imageName: macOS-10.15
                     sendCoverage: "false"
                 mac_python_3_6:
                     python.version: "3.6"
-                    imageName: macos-10.13
+                    imageName: macOS-10.15
                     sendCoverage: "false"
                 mac_python_3_7:
                     python.version: "3.7"
-                    imageName: macos-10.13
+                    imageName: macOS-10.15
                     sendCoverage: "false"
                 windows_python_2_7:
                     python.version: "2.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+soupsieve<2.0; python_version<"3.5"
 PySerial>=3.0,<4.0
 requests>=2.0,<3.0
 intelhex>=2.0,<3.0
@@ -10,6 +11,5 @@ lockfile
 six>=1.0,<2.0
 colorama>=0.3,<0.5
 # When using beautiful soup, the XML parser needs to be installed independently. It is only needed on macOs though.
-soupsieve<2.0; python_version<"3.5"
 beautifulsoup4
 lxml; sys_platform == 'darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ lockfile
 six>=1.0,<2.0
 colorama>=0.3,<0.5
 # When using beautiful soup, the XML parser needs to be installed independently. It is only needed on macOs though.
+soupsieve<2.0; python_version<"3.5"
 beautifulsoup4
 lxml; sys_platform == 'darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-soupsieve<2.0
 PySerial>=3.0,<4.0
 requests>=2.0,<3.0
 intelhex>=2.0,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-soupsieve<2.0; python_version<"3.5"
+soupsieve<2.0
 PySerial>=3.0,<4.0
 requests>=2.0,<3.0
 intelhex>=2.0,<3.0

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,10 @@ def read(fname):
 with open(os.path.join(repository_dir, 'requirements.txt')) as fh:
     requirements = fh.readlines()
 
+# soupsieve is not a direct requirement of this package, but left to it's own
+# devices a version >= 2.0 is installed for Python 2 which is not compatible.
+# Therefore perform the installation of a compatible package before any other
+# packages are installed.
 if sys.version_info.major == 2:
     requirements.insert(0, "soupsieve<2.0")
 

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,6 @@ setup(
     install_requires=requirements,
     tests_require=test_requirements,
     extras_require={
-        "pyocd": ["pyocd>=0.14.0"]
+        "pyocd": ["pyocd==0.14.0"]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import sys
 from distutils.core import setup
 from setuptools import find_packages
 
@@ -37,6 +38,9 @@ def read(fname):
 
 with open(os.path.join(repository_dir, 'requirements.txt')) as fh:
     requirements = fh.readlines()
+
+if sys.version_info.major == 2:
+    requirements.insert(0, "soupsieve<2.0")
 
 with open(os.path.join(repository_dir, 'test_requirements.txt')) as fh:
     test_requirements = fh.readlines()

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,6 @@ setup(
     install_requires=requirements,
     tests_require=test_requirements,
     extras_require={
-        "pyocd": ["pyocd==0.14.0"]
+        "pyocd": ["pyocd>=0.14.0"]
     },
 )

--- a/src/mbed_os_tools/detect/darwin.py
+++ b/src/mbed_os_tools/detect/darwin.py
@@ -43,7 +43,8 @@ def _plist_from_popen(popen):
         return []
     try:
         try:
-            # Try simple and fast first if this fails fall back to the slower but better process
+            # Try simple and fast first if this fails fall back to the slower but
+            # more robust process.
             return loads(out)
         except ExpatError:
             # Beautiful soup ensures the XML is properly formed after it is parsed


### PR DESCRIPTION
### Description

- Fix line length of a comment causing flake8 checks to fail
- Update the macOS VM to one supported by AzurePipelines (the existing one had been removed)
- Set max version of soupsieve on Python 2.7 otherwise an incompatible version is installed.

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
