### PR TITLE
mbedls console print: replace 'daplink_version' by 'interface_version'

### DIFF
--- a/packages/mbed-ls/mbed_lstools/main.py
+++ b/packages/mbed-ls/mbed_lstools/main.py
@@ -49,7 +49,9 @@ def print_mbeds(mbeds, args, simple):
         from prettytable import PrettyTable, HEADER
         columns = ['platform_name', 'platform_name_unique', 'mount_point',
                     'serial_port', 'target_id', 'daplink_version']
-        pt = PrettyTable(columns, junction_char="|", hrules=HEADER)
+        columns_header = ['platform_name', 'platform_name_unique', 'mount_point',
+                    'serial_port', 'target_id', 'interface_version']
+        pt = PrettyTable(columns_header, junction_char="|", hrules=HEADER)
         pt.align = 'l'
         for d in devices:
             pt.add_row([d.get(col, None) or 'unknown' for col in columns])


### PR DESCRIPTION
### Description

With the latest ST Link FW version available in https://www.st.com/en/development-tools/stsw-link007.html
ST-Link FW version is now displayed in the mbedls console print:

````
$ mbedls
| platform_name       | platform_name_unique   | mount_point | serial_port | target_id                | daplink_version |
|---------------------|------------------------|-------------|-------------|--------------------------|-----------------|
| DISCO_H747I         | DISCO_H747I[0]         | D:          | COM13       | 081402210D03E72132477E08 | V3J7M2          |
| DISCO_L475VG_IOT01A | DISCO_L475VG_IOT01A[0] | E:          | COM9        | 07640221683B630A577FF553 | V2J37M26        |
````

@MarceloSalazar proposed to replace "daplink_version" by "interface_version"


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
