### PR TITLE
Bump mbed-ls version

### DIFF
--- a/packages/mbed-ls/setup.py
+++ b/packages/mbed-ls/setup.py
@@ -50,7 +50,7 @@ with open(os.path.join(repository_dir, 'test_requirements.txt')) as fh:
 
 python_requires = '>=2.7.10, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4'
 setup(name='mbed-ls',
-      version='1.7.11',
+      version='1.7.12',
       description=DESCRIPTION,
       long_description=read('README.md'),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
### Description

Bump mbed-ls version in preparation for release of mbed-ls. This release of mbed-ls will add support for ARM_MUSCA_B1, ARM_MUSCA_S1, GR_MANGO, ADV_WISE_1510, ADV_WISE_1530, and ADV_WISE_1570.


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
