### PR TITLE
ci: Remove support for python 2.7

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,10 +19,6 @@ jobs:
         job: test
         strategy:
             matrix:
-                linux_python_2_7:
-                    python.version: "2.7"
-                    imageName: ubuntu-16.04
-                    sendCoverage: "false"
                 linux_python_3_5:
                     python.version: "3.5"
                     imageName: ubuntu-16.04
@@ -35,10 +31,6 @@ jobs:
                     python.version: "3.7"
                     imageName: ubuntu-16.04
                     sendCoverage: "true"
-                mac_python_2_7:
-                    python.version: "2.7"
-                    imageName: macOS-10.15
-                    sendCoverage: "false"
                 mac_python_3_5:
                     python.version: "3.5"
                     imageName: macOS-10.15
@@ -50,10 +42,6 @@ jobs:
                 mac_python_3_7:
                     python.version: "3.7"
                     imageName: macOS-10.15
-                    sendCoverage: "false"
-                windows_python_2_7:
-                    python.version: "2.7"
-                    imageName: vs2017-win2016
                     sendCoverage: "false"
                 windows_python_3_5:
                     python.version: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ if sys.version_info.major == 2:
 with open(os.path.join(repository_dir, 'test_requirements.txt')) as fh:
     test_requirements = fh.readlines()
 
-python_requires = '>=2.7.10, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4'
 setup(
     name="mbed-os-tools",
     version=read("src/mbed_os_tools/VERSION.txt").strip(),
@@ -70,17 +69,15 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python',
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Embedded Systems',
     ),
-    python_requires=python_requires,
+    python_requires=">=3.5,<4",
     install_requires=requirements,
     tests_require=test_requirements,
     extras_require={


### PR DESCRIPTION
### Description
Python 2.7 is not supported therefore not required to be run as part of
CI validations.

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [x] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
