### PR TITLE
Don't require too old mbed-os-tools

### DIFF
--- a/packages/mbed-greentea/requirements.txt
+++ b/packages/mbed-greentea/requirements.txt
@@ -1,2 +1,2 @@
-mbed-os-tools>=0.0.9,<0.1.0
+mbed-os-tools>=0.0.9
 mbed-host-tests>=1.5.0,<2

--- a/packages/mbed-host-tests/requirements.txt
+++ b/packages/mbed-host-tests/requirements.txt
@@ -1,1 +1,1 @@
-mbed-os-tools>=0.0.9,<0.1.0
+mbed-os-tools>=0.0.9

--- a/packages/mbed-ls/requirements.txt
+++ b/packages/mbed-ls/requirements.txt
@@ -1,2 +1,2 @@
 PrettyTable>=0.7.2
-mbed-os-tools>=0.0.9,<0.1.0
+mbed-os-tools>=0.0.9


### PR DESCRIPTION


### Description

mbed-os-tools 1.8.0 is as compatible with 0.0.9 as 0.0.15 was. Remove
the "not greater than" bound on the mbed-os-tools version.


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
