### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -902,7 +902,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 # A time of 0.1 seconds is a fairly arbitrary choice. It needs
                 # to balance CPU utilization and responsiveness to keyboard interrupts.
                 # Checking 10 times a second seems to be stable and responsive.
-                while t.isAlive():
+                while t.is_alive():
                     t.join(0.1)
 
                 test_return_data = test_result_queue.get(False)


### PR DESCRIPTION
### Description

Use `is_alive` in favour of `isAlive` for Python 3.9 compatibility. `is_alive` is present in both Python 2 and 3. Fixes #247 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
