### PR TITLE
version: Fix `setuptools_scm` runtime error

### DIFF
--- a/packages/mbed-ls/requirements.txt
+++ b/packages/mbed-ls/requirements.txt
@@ -1,2 +1,2 @@
-PrettyTable>=0.7.2
+PrettyTable<=1.0.1
 mbed-os-tools>=0.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PySerial>=3.0,<4.0
 requests>=2.0,<3.0
 intelhex>=2.0,<3.0
 future
-PrettyTable>=0.7.2
+PrettyTable<=1.0.1
 fasteners
 appdirs>=1.4,<2.0
 junit-xml>=1.0,<2.0

--- a/src/mbed_os_tools/test/host_tests_runner/__init__.py
+++ b/src/mbed_os_tools/test/host_tests_runner/__init__.py
@@ -20,6 +20,6 @@ Functionality can be overridden by set of plugins which can provide specialised 
 
 """
 
-from setuptools_scm import get_version
+from pkg_resources import get_distribution
 
-__version__ = get_version(root='../../../..', relative_to=__file__)
+__version__ = get_distribution("mbed-os-tools").version


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->
`setuptools_scm` is used to retrieve version during runtime. However, the folder where a package gets installed is not a git
repository which leads to `setuptools_scm` failure.

Use `get_distribution` instead of `setuptools_scm` to get version during runtime.

Fixes https://github.com/ARMmbed/mbed-os-tools/issues/250

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
