### PR TITLE
Fix threading.isAlive

### DIFF
--- a/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
+++ b/packages/mbed-greentea/mbed_greentea/mbed_greentea_cli.py
@@ -904,7 +904,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 # A time of 0.1 seconds is a fairly arbitrary choice. It needs
                 # to balance CPU utilization and responsiveness to keyboard interrupts.
                 # Checking 10 times a second seems to be stable and responsive.
-                while t.isAlive():
+                while t.is_alive():
                     t.join(0.1)
 
                 test_return_data = test_result_queue.get(False)


### PR DESCRIPTION

### Description

In python 3.8 a deprecation message was introduced and since 3.9 `threading.isAlive`
was removed in favour of `threading.is_alive` https://bugs.python.org/issue37804

I mark this as a fix since mbed greentea is effectively broken on system with the most recent python 3.9.
Note I don't know when `threading.is_alive` was introduced so I don't know what older versions of python get excluded by that change.

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@donatieng @adbridge @Patater 
