### PR TITLE
update prettytable version on python3

### DIFF
--- a/packages/mbed-ls/requirements.txt
+++ b/packages/mbed-ls/requirements.txt
@@ -1,2 +1,3 @@
-PrettyTable<=1.0.1
+PrettyTable<=1.0.1; python_version < '3.6'
+prettytable>=2.0,<3.0; python_version >= '3.6'
 mbed-os-tools>=0.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ PySerial>=3.0,<4.0
 requests>=2.0,<3.0
 intelhex>=2.0,<3.0
 future
-PrettyTable<=1.0.1
+PrettyTable<=1.0.1; python_version < '3.6'
+prettytable>=2.0,<3.0; python_version >= '3.6'
 fasteners
 appdirs>=1.4,<2.0
 junit-xml>=1.0,<2.0


### PR DESCRIPTION
### Description

Fixe prettyTable version conflict if installed pyocd>=0.30.2. Issue: #256 


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
