### PR TITLE
ci: Drop Python 3.5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,10 +36,6 @@ stages:
               python.version: "2.7"
               imageName: ubuntu-16.04
               sendCoverage: "false"
-            linux_python_3_5:
-              python.version: "3.5"
-              imageName: ubuntu-16.04
-              sendCoverage: "false"
             linux_python_3_6:
               python.version: "3.6"
               imageName: ubuntu-16.04
@@ -56,10 +52,6 @@ stages:
               python.version: "2.7"
               imageName: macOS-10.15
               sendCoverage: "false"
-            mac_python_3_5:
-              python.version: "3.5"
-              imageName: macOS-10.15
-              sendCoverage: "false"
             mac_python_3_6:
               python.version: "3.6"
               imageName: macOS-10.15
@@ -74,10 +66,6 @@ stages:
               sendCoverage: "false"
             windows_python_2_7:
               python.version: "2.7"
-              imageName: vs2017-win2016
-              sendCoverage: "false"
-            windows_python_3_5:
-              python.version: "3.5"
               imageName: vs2017-win2016
               sendCoverage: "false"
             windows_python_3_6:


### PR DESCRIPTION

### Description
Python 3.5 packages have become unavailable, causing CI to fail.
Additionally, Python 3.5 has reached end-of-life.



### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
