### PR TITLE
Allow to pass the file format to pyocd

### DIFF
--- a/src/mbed_os_tools/test/__init__.py
+++ b/src/mbed_os_tools/test/__init__.py
@@ -359,6 +359,13 @@ def init_host_test_cli_params():
         help="Prints package version and exits",
     )
 
+    parser.add_option(
+        "",
+        "--format",
+        dest="format",
+        help="Image file format passed to pyocd (elf, bin, hex, axf...).",
+    )
+
     parser.description = (
         """Flash, reset and perform host supervised tests on mbed platforms"""
     )

--- a/src/mbed_os_tools/test/host_tests_plugins/module_copy_pyocd.py
+++ b/src/mbed_os_tools/test/host_tests_plugins/module_copy_pyocd.py
@@ -86,7 +86,7 @@ class HostTestPluginCopyMethod_pyOCD(HostTestPluginBase):
 
             # Program the file
             programmer = FileProgrammer(session)
-            programmer.program(image_path)
+            programmer.program(image_path, format=kwargs['format'])
 
         return True
 


### PR DESCRIPTION
### Description

<!--
    **Required**
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/v5.11/contributing/workflow.html (Pull request template)
-->
This adds an option to `mbedhtrun` to accept the image file format to be passed and forward it to `pyocd`.

### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@MarceloSalazar 