### PR TITLE
Upgrade Azure testing images and drop CI testing of Python 2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,10 +32,6 @@ stages:
         strategy:
           maxParallel: 10
           matrix:
-            linux_python_2_7:
-              python.version: "2.7"
-              imageName: ubuntu-16.04
-              sendCoverage: "false"
             linux_python_3_6:
               python.version: "3.6"
               imageName: ubuntu-20.04
@@ -48,10 +44,6 @@ stages:
               python.version: "3.8"
               imageName: ubuntu-20.04
               sendCoverage: "true"
-            mac_python_2_7:
-              python.version: "2.7"
-              imageName: macOS-10.15
-              sendCoverage: "false"
             mac_python_3_6:
               python.version: "3.6"
               imageName: macOS-10.15
@@ -63,10 +55,6 @@ stages:
             mac_python_3_8:
               python.version: "3.8"
               imageName: macOS-10.15
-              sendCoverage: "false"
-            windows_python_2_7:
-              python.version: "2.7"
-              imageName: vs2017-win2016
               sendCoverage: "false"
             windows_python_3_6:
               python.version: "3.6"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,15 +58,15 @@ stages:
               sendCoverage: "false"
             windows_python_3_6:
               python.version: "3.6"
-              imageName: vs2017-win2016
+              imageName: windows-2019
               sendCoverage: "false"
             windows_python_3_7:
               python.version: "3.7"
-              imageName: vs2017-win2016
+              imageName: windows-2019
               sendCoverage: "false"
             windows_python_3_8:
               python.version: "3.8"
-              imageName: vs2017-win2016
+              imageName: windows-2019
               sendCoverage: "false"
 
         pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ stages:
       - job: code_style_check
 
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-20.04
 
         steps:
           - task: UsePythonVersion@0
@@ -38,15 +38,15 @@ stages:
               sendCoverage: "false"
             linux_python_3_6:
               python.version: "3.6"
-              imageName: ubuntu-16.04
+              imageName: ubuntu-20.04
               sendCoverage: "false"
             linux_python_3_7:
               python.version: "3.7"
-              imageName: ubuntu-16.04
+              imageName: ubuntu-20.04
               sendCoverage: "false"
             linux_python_3_8:
               python.version: "3.8"
-              imageName: ubuntu-16.04
+              imageName: ubuntu-20.04
               sendCoverage: "true"
             mac_python_2_7:
               python.version: "2.7"
@@ -181,7 +181,7 @@ stages:
           runOnce:
             deploy:
               pool:
-                vmImage: 'ubuntu-latest'
+                vmImage: 'ubuntu-20.04'
               steps:
                 - checkout: self
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,6 +150,8 @@ stages:
     jobs:
       - job: ChecksPassing
         displayName: 'Checks Passing'
+        pool:
+          vmImage: ubuntu-20.04
         # A dummy job is required due to a bug in Azure which runs the previous job if nothing is defined.
         steps:
           - bash: echo "All prerequisite stages have passed and the package should be suitable for release."


### PR DESCRIPTION
### Description

Azure dropped Ubuntu 16.04, so upgrade to 20.04 image which will work until that image is also removed at some point in the future. Azure will also be dropping the windows version we were using, so upgrade to windows-2019. Python 2 is also dropped from Azure CI, as that's been made less readily available.


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
