### PR TITLE
ci: Specify the image for PyPIProductionRelease

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,6 +165,8 @@ stages:
     jobs:
       - deployment: PyPIProductionRelease
         displayName: 'PyPI Production Release'
+        pool:
+          vmImage: ubuntu-20.04
         # Create an environment to keep track of PyPI releases
         environment: 'PyPI Release'
         strategy:


### PR DESCRIPTION
### Description

Similarly to the CiCheckpoint stage, the PyPIProductionRelease also needs updating.

Without specifying which image to use for the PyPIProductionRelease
stage, Azure will default to using Ubuntu 16.04. However, Ubuntu 16.04
has been removed from Azure, so the pipeline stage will end up
cancelling itself with the following error:

    ##[warning]An image label with the label Ubuntu16 does not exist.
    ,##[error]The remote provider was unable to process the request.
    Pool: Azure Pipelines
    Image: Ubuntu16

Explicitly specify the image to use in the PyPIProductionRelease stage
to ensure the stage doesn't cancel itself.



### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
