### PR TITLE
Enlarge MAX_COMPOSITE_DEVICE_SUBDEVICES for windows

### DIFF
--- a/src/mbed_os_tools/detect/windows.py
+++ b/src/mbed_os_tools/detect/windows.py
@@ -33,7 +33,7 @@ else:
     import winreg
 
 
-MAX_COMPOSITE_DEVICE_SUBDEVICES = 5
+MAX_COMPOSITE_DEVICE_SUBDEVICES = 8
 MBED_STORAGE_DEVICE_VENDOR_STRINGS = [
     "ven_mbed",
     "ven_segger",


### PR DESCRIPTION
### Description

Some interfaces, e.g. Nuvoton's Nu-Link2 can have more subdevices than the limit defined by `MAX_COMPOSITE_DEVICE_SUBDEVICES` for windows. This PR tries to enlarge the limit to enable these interfaces.


### Pull request type

<!--
    **Required**
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
