### PR TITLE
Import setup from setuptools

### DIFF
--- a/packages/mbed-greentea/setup.py
+++ b/packages/mbed-greentea/setup.py
@@ -24,8 +24,7 @@ Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 
 import os
 from io import open
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 DESCRIPTION = "mbed 3.0 onwards test suite, codename Greentea. The test suite is a collection of tools that enable automated testing on mbed-enabled platforms"
 OWNER_NAMES = 'Anna Bridge, Qinghao Shi'

--- a/packages/mbed-host-tests/setup.py
+++ b/packages/mbed-host-tests/setup.py
@@ -23,9 +23,8 @@ Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 """
 
 import os
-from distutils.core import setup
 from io import open
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 DESCRIPTION = "mbed tools used to flash, reset and supervise test execution for mbed-enabled devices"
 OWNER_NAMES = 'Qinghao Shi'

--- a/packages/mbed-ls/setup.py
+++ b/packages/mbed-ls/setup.py
@@ -20,9 +20,8 @@ Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 """
 
 import os
-from distutils.core import setup
 from io import open
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 DESCRIPTION = "mbed-ls is a Python module that detects and lists mbed-enabled devices connected to the host computer"
 OWNER_NAMES = 'Graham Hammond, Mark Edgeworth'

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@
 
 import os
 import sys
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 DESCRIPTION = "The tools to build, test, and work with Mbed OS"
 OWNER_NAMES = "Jimmy Brisson, Brian Daniels"


### PR DESCRIPTION
### Description

setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

In this case, the best way to deal with the problem is to just use setuptools' setup().

Fixes: https://bugs.debian.org/1022482 and https://bugs.debian.org/1022538

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change