### PR TITLE
Replace deprecated assertDictContainsSubset

### DIFF
--- a/packages/mbed-ls/test/mbedls_toolsbase.py
+++ b/packages/mbed-ls/test/mbedls_toolsbase.py
@@ -418,7 +418,7 @@ Remount count: 0
             self.assertIsNotNone(ret_with_details[0])
             self.assertEqual(ret[0]['target_id'], new_device_id)
             self.assertEqual(ret_with_details[0]['daplink_automation_allowed'], '0')
-            self.assertDictContainsSubset(ret[0], ret_with_details[0])
+            self.assertLessEqual(ret[0].items(), ret_with_details[0].items())
             _read_htm.assert_called_with(device['mount_point'])
             _up_details.assert_called_with(device['mount_point'])
 
@@ -494,7 +494,7 @@ Remount count: 0
             self.assertIsNotNone(ret_with_details[0])
             self.assertEqual(ret[0]['target_id'], new_device_id)
             self.assertEqual(ret_with_details[0]['daplink_automation_allowed'], '0')
-            self.assertDictContainsSubset(ret[0], ret_with_details[0])
+            self.assertLessEqual(ret[0].items(), ret_with_details[0].items())
             _read_htm.assert_called_with(device['mount_point'])
             _up_details.assert_called_with(device['mount_point'])
 
@@ -516,7 +516,7 @@ Remount count: 0
             self.assertIsNotNone(ret_with_details[0])
             self.assertEqual(ret[0]['target_id'], new_device_id)
             self.assertEqual(ret_with_details[0]['daplink_automation_allowed'], '0')
-            self.assertDictContainsSubset(ret[0], ret_with_details[0])
+            self.assertLessEqual(ret[0].items(), ret_with_details[0].items())
             _read_htm.assert_called_with(device['mount_point'])
             _up_details.assert_called_with(device['mount_point'])
 

--- a/test/detect/mbedls_toolsbase.py
+++ b/test/detect/mbedls_toolsbase.py
@@ -413,7 +413,7 @@ Remount count: 0
             self.assertIsNotNone(ret_with_details[0])
             self.assertEqual(ret[0]['target_id'], new_device_id)
             self.assertEqual(ret_with_details[0]['daplink_automation_allowed'], '0')
-            self.assertDictContainsSubset(ret[0], ret_with_details[0])
+            self.assertLessEqual(ret[0].items(), ret_with_details[0].items())
             _read_htm.assert_called_with(device['mount_point'])
             _up_details.assert_called_with(device['mount_point'])
 
@@ -489,7 +489,7 @@ Remount count: 0
             self.assertIsNotNone(ret_with_details[0])
             self.assertEqual(ret[0]['target_id'], new_device_id)
             self.assertEqual(ret_with_details[0]['daplink_automation_allowed'], '0')
-            self.assertDictContainsSubset(ret[0], ret_with_details[0])
+            self.assertLessEqual(ret[0].items(), ret_with_details[0].items())
             _read_htm.assert_called_with(device['mount_point'])
             _up_details.assert_called_with(device['mount_point'])
 
@@ -511,7 +511,7 @@ Remount count: 0
             self.assertIsNotNone(ret_with_details[0])
             self.assertEqual(ret[0]['target_id'], new_device_id)
             self.assertEqual(ret_with_details[0]['daplink_automation_allowed'], '0')
-            self.assertDictContainsSubset(ret[0], ret_with_details[0])
+            self.assertLessEqual(ret[0].items(), ret_with_details[0].items())
             _read_htm.assert_called_with(device['mount_point'])
             _up_details.assert_called_with(device['mount_point'])
 


### PR DESCRIPTION
The method was deprecated in Python 3.2.  Replace it with
assertLessEqual, which uses set logic to perform the same operation.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change